### PR TITLE
Dart 2.7 compat + Travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: dart
 
 jobs:
   include:
-    - dart: "2.4.1"
-      name: "SDK: 2.4.1"
+    - dart: "2.4.0"
+      name: "SDK: 2.4.0"
       script:
         - dartanalyzer .
         - pub run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: dart
+
+jobs:
+  include:
+    - dart: "2.4.1"
+      name: "SDK: 2.4.1"
+      script:
+        - dartanalyzer .
+        - pub run test
+    - dart: stable
+      name: "SDK: stable"
+      script:
+        - dartanalyzer .
+        - pub run test
+        - dartfmt -n --set-exit-if-changed .
+        - pub publish --dry-run
+    - dart: dev
+      name: "SDK: dev"
+      script:
+        - dartanalyzer .
+        - pub run test
+
+cache:
+  directories:
+    - "$HOME/.pub-cache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Setup Travis CI
+
 ## 1.0.1
 
 - Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,7 @@
 FROM drydock-prod.workiva.net/workiva/dart2_base_image:1
 
 WORKDIR /build/
-COPY . .
+COPY pubspec.yaml .
 RUN pub get
-
-# TODO: move these checks to Travis CI when OSS
-RUN pub publish --dry-run
-RUN dartfmt -n --set-exit-if-changed .
-RUN pub run test
 
 FROM scratch

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,7 @@
 name: workiva_analysis_options
 version: 1.0.1
 homepage: https://github.com/Workiva/workiva_analysis_options
-
 description: Workiva's shared static analysis options.
-
-authors:
-  - Workiva Client Platform Team <clientplatform@workiva.com>
 
 environment:
   sdk: ">=2.4.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: workiva_analysis_options
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/Workiva/workiva_analysis_options
 description: Workiva's shared static analysis options.
 


### PR DESCRIPTION
- Removed the `authors` field from `pubspec.yaml` since it is deprecated in Dart 2.7
- Move CI steps from workiva-build to Travis CI now that this repo is OSS