### PR TITLE
CPLAT-10333 Ignore uri_has_not_been_generated Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add ignore for uri_has_not_been_generated errors
+
 ## 1.0.2
 
 - Setup Travis CI

--- a/lib/v1.recommended.yaml
+++ b/lib/v1.recommended.yaml
@@ -124,9 +124,6 @@ analyzer:
     use_function_type_syntax_for_parameters: warning
     use_rethrow_when_possible: warning
 
-    # Ignore error:
-    uri_has_not_been_generated: ignore
-
 linter:
   rules:
     - always_require_non_null_named_parameters

--- a/lib/v1.recommended.yaml
+++ b/lib/v1.recommended.yaml
@@ -124,6 +124,9 @@ analyzer:
     use_function_type_syntax_for_parameters: warning
     use_rethrow_when_possible: warning
 
+    # Ignore error:
+    uri_has_not_been_generated: ignore
+
 linter:
   rules:
     - always_require_non_null_named_parameters

--- a/lib/v1.yaml
+++ b/lib/v1.yaml
@@ -135,6 +135,10 @@ analyzer:
     valid_regexps: warning
     void_checks: warning
 
+    # Ignore ungenerated uri error:
+    # See: <https://github.com/Workiva/over_react/blob/new_boilerplate_wip/doc/new_boilerplate_migration.md#ignore-ungenerated-warnings-project-wide>.
+    uri_has_not_been_generated: ignore
+
 linter:
   rules:
     - annotate_overrides


### PR DESCRIPTION
To support the new over_react boilerplate and silence ungenerated errors, we need to ignore the `uri_has_not_been_generated` analyzer error by default.

See: [New OverReact Boilerplate Migration Guide](https://github.com/Workiva/over_react/blob/new_boilerplate_wip/doc/new_boilerplate_migration.md#ignore-ungenerated-warnings-project-wide)

Please Review: @greglittlefield-wf @aaronlademann-wf @joebingham-wk 