### PR TITLE
v2 analysis options

### DIFF
--- a/lib/v1.optional.yaml
+++ b/lib/v1.optional.yaml
@@ -69,7 +69,7 @@ include: package:workiva_analysis_options/v1.recommended.yaml
 
 analyzer:
   errors:
-    # Promote enabled lints to errors:
+    # Promote enabled lints to warnings:
     always_declare_return_types: warning
     always_put_required_named_parameters_first: warning
     always_specify_types: warning
@@ -83,7 +83,6 @@ analyzer:
     control_flow_in_finally: warning
     directives_ordering: warning
     flutter_style_todos: warning
-    invariant_booleans: warning
     literal_only_boolean_expressions: warning
     non_constant_identifier_names: warning
     parameter_assignments: warning
@@ -120,7 +119,6 @@ linter:
     - control_flow_in_finally
     - directives_ordering
     - flutter_style_todos
-    - invariant_booleans
     - literal_only_boolean_expressions
     - non_constant_identifier_names
     - parameter_assignments

--- a/lib/v1.recommended.yaml
+++ b/lib/v1.recommended.yaml
@@ -65,7 +65,7 @@ include: package:workiva_analysis_options/v1.yaml
 
 analyzer:
   errors:
-    # Promote enabled lints to errors:
+    # Promote enabled lints to warnings:
     always_require_non_null_named_parameters: warning
     avoid_bool_literals_in_conditional_expressions: warning
     avoid_function_literals_in_foreach_calls: warning

--- a/lib/v1.yaml
+++ b/lib/v1.yaml
@@ -74,7 +74,7 @@ analyzer:
     sdk_version_ui_as_code: warning
     sdk_version_ui_as_code_in_const_context: warning
 
-    # Promote some builtin hints/infos/warnings to errors:
+    # Promote some builtin hints to warnings:
     dead_code: warning
     duplicate_hidden_name: warning
     duplicate_import: warning
@@ -88,7 +88,7 @@ analyzer:
     unused_local_variable: warning
     unused_shown_name: warning
 
-    # Promote enabled lints to errors:
+    # Promote enabled lints to warnings:
     annotate_overrides: warning
     avoid_double_and_int_checks: warning
     avoid_empty_else: warning

--- a/lib/v2.recommended.yaml
+++ b/lib/v2.recommended.yaml
@@ -1,0 +1,185 @@
+# Copyright 2019 Workiva, Inc.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This software is derived from pedantic (https://github.com/dart-lang/pedantic)
+# with separate copyright notices and license terms:
+#
+# Copyright 2017, the Dart project authors. All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided
+# with the distribution.
+# Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Every lint in this file is categorized as "recommended".
+#
+# For context on that decision or to discuss a change for any individual lint,
+# visit this issue and search for the lint by its name:
+# https://github.com/Workiva/workiva_analysis_options/issues/2
+
+# This file also includes all of the required rules.
+include: package:workiva_analysis_options/v1.yaml
+
+analyzer:
+  errors:
+    # Promote enabled lints to errors:
+    always_require_non_null_named_parameters: warning
+    avoid_bool_literals_in_conditional_expressions: warning
+    avoid_function_literals_in_foreach_calls: warning
+    avoid_implementing_value_types: warning
+    avoid_null_checks_in_equality_operators: warning
+    avoid_positional_boolean_parameters: warning
+    avoid_relative_lib_imports: warning
+    avoid_renaming_method_parameters: warning
+    avoid_returning_this: warning
+    avoid_returning_null: warning
+    avoid_returning_null_for_future: warning
+    avoid_returning_null_for_void: warning
+    avoid_setters_without_getters: warning
+    avoid_types_on_closure_parameters: warning
+    avoid_unused_constructor_parameters: warning
+    cascade_invocations: warning
+    comment_references: warning
+    curly_braces_in_flow_control_structures: warning
+    join_return_with_assignment: warning
+    omit_local_variable_types: warning
+    overridden_fields: warning
+    package_api_docs: warning
+    package_prefixed_library_names: warning
+    package_names: warning
+    prefer_adjacent_string_concatenation: warning
+    prefer_asserts_in_initializer_lists: warning
+    prefer_collection_literals: warning
+    prefer_conditional_assignment: warning
+    prefer_const_declarations: warning
+    provide_deprecation_message: warning
+    prefer_final_fields: warning
+    prefer_final_in_for_each: warning
+    prefer_final_locals: warning
+    prefer_function_declarations_over_variables: warning
+    prefer_if_elements_to_conditional_expressions: warning
+    prefer_initializing_formals: warning
+    prefer_inlined_adds: warning
+    prefer_interpolation_to_compose_strings: warning
+    prefer_iterable_whereType: warning
+    prefer_mixin: warning
+    prefer_null_aware_operators: warning
+    prefer_single_quotes: warning
+    prefer_spread_collections: warning
+    prefer_void_to_null: warning
+    sort_pub_dependencies: warning
+    test_types_in_equals: warning
+    type_annotate_public_apis: warning
+    unawaited_futures: warning
+    unnecessary_await_in_return: warning
+    unnecessary_brace_in_string_interps: warning
+    unnecessary_getters_setters: warning
+    unnecessary_lambdas: warning
+    unnecessary_parenthesis: warning
+    unnecessary_overrides: warning
+    unnecessary_this: warning
+    use_function_type_syntax_for_parameters: warning
+    use_rethrow_when_possible: warning
+
+linter:
+  rules:
+    - always_require_non_null_named_parameters
+    - avoid_bool_literals_in_conditional_expressions
+    - avoid_function_literals_in_foreach_calls
+    - avoid_implementing_value_types
+    - avoid_null_checks_in_equality_operators
+    - avoid_positional_boolean_parameters
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_returning_this
+    - avoid_returning_null
+    - avoid_returning_null_for_future
+    - avoid_returning_null_for_void
+    - avoid_setters_without_getters
+    - avoid_types_on_closure_parameters
+    - avoid_unused_constructor_parameters
+    - cascade_invocations
+    - comment_references
+    - curly_braces_in_flow_control_structures
+    - join_return_with_assignment
+    - omit_local_variable_types
+    - overridden_fields
+    - package_api_docs
+    - package_prefixed_library_names
+    - package_names
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_declarations
+    - provide_deprecation_message
+    - prefer_final_fields
+    - prefer_final_in_for_each
+    - prefer_final_locals
+    - prefer_function_declarations_over_variables
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    - prefer_interpolation_to_compose_strings
+    - prefer_iterable_whereType
+    - prefer_mixin
+    - prefer_null_aware_operators
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - prefer_void_to_null
+    - sort_pub_dependencies
+    - test_types_in_equals
+    - type_annotate_public_apis
+    - unawaited_futures
+    - unnecessary_await_in_return
+    - unnecessary_brace_in_string_interps
+    - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_parenthesis
+    - unnecessary_overrides
+    - unnecessary_this
+    - use_function_type_syntax_for_parameters
+    - use_rethrow_when_possible

--- a/lib/v2.recommended.yaml
+++ b/lib/v2.recommended.yaml
@@ -65,12 +65,11 @@ include: package:workiva_analysis_options/v1.yaml
 
 analyzer:
   errors:
-    # Promote enabled lints to errors:
+    # Promote enabled lints to warnings:
     always_declare_return_types: warning
     always_put_required_named_parameters_first: warning
     always_require_non_null_named_parameters: warning
     avoid_bool_literals_in_conditional_expressions: warning
-    avoid_field_initializers_in_const_classes: warning
     avoid_function_literals_in_foreach_calls: warning
     avoid_implementing_value_types: warning
     avoid_js_rounded_ints: warning
@@ -84,6 +83,7 @@ analyzer:
     avoid_returning_null_for_void: warning
     avoid_setters_without_getters: warning
     avoid_slow_async_io: warning
+    avoid_type_to_string: warning
     avoid_types_on_closure_parameters: warning
     avoid_unused_constructor_parameters: warning
     cascade_invocations: warning
@@ -91,10 +91,6 @@ analyzer:
     control_flow_in_finally: warning
     curly_braces_in_flow_control_structures: warning
     directives_ordering: warning
-    duplicate_ignore: warning
-    invalid_required_named_param: warning
-    invalid_required_positional_param: warning
-    invariant_booleans: warning
     join_return_with_assignment: warning
     literal_only_boolean_expressions: warning
     omit_local_variable_types: warning
@@ -135,15 +131,15 @@ analyzer:
     unawaited_futures: warning
     unnecessary_await_in_return: warning
     unnecessary_brace_in_string_interps: warning
-    unnecessary_cast: warning
     unnecessary_getters_setters: warning
     unnecessary_lambdas: warning
     unnecessary_parenthesis: warning
     unnecessary_overrides: warning
+    unnecessary_string_escapes: warning
+    unnecessary_string_interpolations: warning
     unnecessary_this: warning
     use_function_type_syntax_for_parameters: warning
     use_rethrow_when_possible: warning
-    use_setters_to_change_properties: warning
     use_string_buffers: warning
     use_to_and_as_if_applicable: warning
 
@@ -153,7 +149,6 @@ linter:
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
     - avoid_bool_literals_in_conditional_expressions
-    - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
     - avoid_js_rounded_ints
@@ -167,6 +162,7 @@ linter:
     - avoid_returning_null_for_void
     - avoid_setters_without_getters
     - avoid_slow_async_io
+    - avoid_type_to_string
     - avoid_types_on_closure_parameters
     - avoid_unused_constructor_parameters
     - cascade_invocations
@@ -174,10 +170,6 @@ linter:
     - control_flow_in_finally
     - curly_braces_in_flow_control_structures
     - directives_ordering
-    - duplicate_ignore
-    - invalid_required_named_param
-    - invalid_required_positional_param
-    - invariant_booleans
     - join_return_with_assignment
     - literal_only_boolean_expressions
     - omit_local_variable_types
@@ -218,14 +210,14 @@ linter:
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
-    - unnecessary_cast
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_parenthesis
     - unnecessary_overrides
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
     - unnecessary_this
     - use_function_type_syntax_for_parameters
     - use_rethrow_when_possible
-    - use_setters_to_change_properties
     - use_string_buffers
     - use_to_and_as_if_applicable

--- a/lib/v2.recommended.yaml
+++ b/lib/v2.recommended.yaml
@@ -66,10 +66,14 @@ include: package:workiva_analysis_options/v1.yaml
 analyzer:
   errors:
     # Promote enabled lints to errors:
+    always_declare_return_types: warning
+    always_put_required_named_parameters_first: warning
     always_require_non_null_named_parameters: warning
     avoid_bool_literals_in_conditional_expressions: warning
+    avoid_field_initializers_in_const_classes: warning
     avoid_function_literals_in_foreach_calls: warning
     avoid_implementing_value_types: warning
+    avoid_js_rounded_ints: warning
     avoid_null_checks_in_equality_operators: warning
     avoid_positional_boolean_parameters: warning
     avoid_relative_lib_imports: warning
@@ -79,12 +83,20 @@ analyzer:
     avoid_returning_null_for_future: warning
     avoid_returning_null_for_void: warning
     avoid_setters_without_getters: warning
+    avoid_slow_async_io: warning
     avoid_types_on_closure_parameters: warning
     avoid_unused_constructor_parameters: warning
     cascade_invocations: warning
     comment_references: warning
+    control_flow_in_finally: warning
     curly_braces_in_flow_control_structures: warning
+    directives_ordering: warning
+    duplicate_ignore: warning
+    invalid_required_named_param: warning
+    invalid_required_positional_param: warning
+    invariant_booleans: warning
     join_return_with_assignment: warning
+    literal_only_boolean_expressions: warning
     omit_local_variable_types: warning
     overridden_fields: warning
     package_api_docs: warning
@@ -94,8 +106,11 @@ analyzer:
     prefer_asserts_in_initializer_lists: warning
     prefer_collection_literals: warning
     prefer_conditional_assignment: warning
+    prefer_const_constructors_in_immutables: warning
     prefer_const_declarations: warning
-    provide_deprecation_message: warning
+    prefer_const_literals_to_create_immutables: warning
+    prefer_constructors_over_static_methods: warning
+    prefer_typing_uninitialized_variables: warning
     prefer_final_fields: warning
     prefer_final_in_for_each: warning
     prefer_final_locals: warning
@@ -103,6 +118,7 @@ analyzer:
     prefer_if_elements_to_conditional_expressions: warning
     prefer_initializing_formals: warning
     prefer_inlined_adds: warning
+    prefer_int_literals: warning
     prefer_interpolation_to_compose_strings: warning
     prefer_iterable_whereType: warning
     prefer_mixin: warning
@@ -110,12 +126,16 @@ analyzer:
     prefer_single_quotes: warning
     prefer_spread_collections: warning
     prefer_void_to_null: warning
+    provide_deprecation_message: warning
     sort_pub_dependencies: warning
+    sort_unnamed_constructors_first: warning
     test_types_in_equals: warning
+    throw_in_finally: warning
     type_annotate_public_apis: warning
     unawaited_futures: warning
     unnecessary_await_in_return: warning
     unnecessary_brace_in_string_interps: warning
+    unnecessary_cast: warning
     unnecessary_getters_setters: warning
     unnecessary_lambdas: warning
     unnecessary_parenthesis: warning
@@ -123,13 +143,20 @@ analyzer:
     unnecessary_this: warning
     use_function_type_syntax_for_parameters: warning
     use_rethrow_when_possible: warning
+    use_setters_to_change_properties: warning
+    use_string_buffers: warning
+    use_to_and_as_if_applicable: warning
 
 linter:
   rules:
+    - always_declare_return_types
+    - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
     - avoid_bool_literals_in_conditional_expressions
+    - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
+    - avoid_js_rounded_ints
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_relative_lib_imports
@@ -139,12 +166,20 @@ linter:
     - avoid_returning_null_for_future
     - avoid_returning_null_for_void
     - avoid_setters_without_getters
+    - avoid_slow_async_io
     - avoid_types_on_closure_parameters
     - avoid_unused_constructor_parameters
     - cascade_invocations
     - comment_references
+    - control_flow_in_finally
     - curly_braces_in_flow_control_structures
+    - directives_ordering
+    - duplicate_ignore
+    - invalid_required_named_param
+    - invalid_required_positional_param
+    - invariant_booleans
     - join_return_with_assignment
+    - literal_only_boolean_expressions
     - omit_local_variable_types
     - overridden_fields
     - package_api_docs
@@ -154,8 +189,11 @@ linter:
     - prefer_asserts_in_initializer_lists
     - prefer_collection_literals
     - prefer_conditional_assignment
+    - prefer_const_constructors_in_immutables
     - prefer_const_declarations
-    - provide_deprecation_message
+    - prefer_const_literals_to_create_immutables
+    - prefer_constructors_over_static_methods
+    - prefer_typing_uninitialized_variables
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
@@ -163,6 +201,7 @@ linter:
     - prefer_if_elements_to_conditional_expressions
     - prefer_initializing_formals
     - prefer_inlined_adds
+    - prefer_int_literals
     - prefer_interpolation_to_compose_strings
     - prefer_iterable_whereType
     - prefer_mixin
@@ -170,12 +209,16 @@ linter:
     - prefer_single_quotes
     - prefer_spread_collections
     - prefer_void_to_null
+    - provide_deprecation_message
     - sort_pub_dependencies
+    - sort_unnamed_constructors_first
     - test_types_in_equals
+    - throw_in_finally
     - type_annotate_public_apis
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
+    - unnecessary_cast
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_parenthesis
@@ -183,3 +226,6 @@ linter:
     - unnecessary_this
     - use_function_type_syntax_for_parameters
     - use_rethrow_when_possible
+    - use_setters_to_change_properties
+    - use_string_buffers
+    - use_to_and_as_if_applicable

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -81,10 +81,9 @@ analyzer:
     duplicate_shown_name: warning
     unused_catch_clause: warning
     unused_catch_stack: warning
-    # Disabled during the Dart 2.13 transition
-    # unused_element: warning
-    # unused_field: warning
-    # unused_import: warning
+    unused_element: warning
+    unused_field: warning
+    unused_import: warning
     unused_local_variable: warning
     unused_shown_name: warning
 
@@ -101,6 +100,7 @@ analyzer:
     await_only_futures: warning
     camel_case_extensions: warning
     camel_case_types: warning
+    can_be_null_after_null_aware: warning
     cancel_subscriptions: warning
     close_sinks: warning
     empty_catches: warning
@@ -108,11 +108,16 @@ analyzer:
     empty_statements: warning
     file_names: warning
     hash_and_equals: warning
+    invalid_use_of_protected_member: warning
+    invalid_use_of_visible_for_testing_member: warning
     implementation_imports: warning
     iterable_contains_unrelated_type: warning
     library_names: warning
     library_prefixes: warning
     list_remove_unrelated_type: warning
+    missing_required_param: warning
+    missing_return: warning
+    must_call_super: warning
     no_adjacent_strings_in_list: warning
     no_duplicate_case_values: warning
     null_closures: warning
@@ -125,14 +130,14 @@ analyzer:
     prefer_is_not_empty: warning
     recursive_getters: warning
     slash_for_doc_comments: warning
+    subtype_of_sealed_class: warning
     type_init_formals: warning
     unnecessary_const: warning
     unnecessary_new: warning
     unnecessary_null_aware_assignments: warning
     unnecessary_null_in_if_null_operators: warning
     unnecessary_statements: warning
-    # Disabled during the Dart 2.13 transition
-    # unsafe_html: warning
+    unsafe_html: warning
     unrelated_type_equality_checks: warning
     valid_regexps: warning
     void_checks: warning
@@ -155,6 +160,7 @@ linter:
     - await_only_futures
     - camel_case_extensions
     - camel_case_types
+    - can_be_null_after_null_aware
     - cancel_subscriptions
     - close_sinks
     - empty_catches
@@ -162,11 +168,16 @@ linter:
     - empty_statements
     - file_names
     - hash_and_equals
+    - invalid_use_of_protected_member
+    - invalid_use_of_visible_for_testing_member
     - implementation_imports
     - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
     - list_remove_unrelated_type
+    - missing_required_param
+    - missing_return
+    - must_call_super
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - null_closures
@@ -179,14 +190,14 @@ linter:
     - prefer_is_not_empty
     - recursive_getters
     - slash_for_doc_comments
+    - subtype_of_sealed_class
     - type_init_formals
     - unnecessary_const
     - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
     - unnecessary_statements
-    # Disabled during the Dart 2.13 transition
-    # - unsafe_html
+    - unsafe_html
     - unrelated_type_equality_checks
     - valid_regexps
     - void_checks

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -74,11 +74,22 @@ analyzer:
     sdk_version_ui_as_code: warning
     sdk_version_ui_as_code_in_const_context: warning
 
-    # Promote some builtin hints/infos/warnings to errors:
+    # Promote some builtin hints to warnings:
+    can_be_null_after_null_aware: warning
     dead_code: warning
     duplicate_hidden_name: warning
+    duplicate_ignore: warning
     duplicate_import: warning
     duplicate_shown_name: warning
+    invalid_required_named_param: warning
+    invalid_required_positional_param: warning
+    invalid_use_of_protected_member: warning
+    invalid_use_of_visible_for_testing_member: warning
+    missing_required_param: warning
+    missing_return: warning
+    must_call_super: warning
+    subtype_of_sealed_class: warning
+    unnecessary_cast: warning
     unused_catch_clause: warning
     unused_catch_stack: warning
     unused_element: warning
@@ -87,7 +98,7 @@ analyzer:
     unused_local_variable: warning
     unused_shown_name: warning
 
-    # Promote enabled lints to errors:
+    # Promote enabled lints to warnings:
     annotate_overrides: warning
     avoid_double_and_int_checks: warning
     avoid_empty_else: warning
@@ -100,7 +111,6 @@ analyzer:
     await_only_futures: warning
     camel_case_extensions: warning
     camel_case_types: warning
-    can_be_null_after_null_aware: warning
     cancel_subscriptions: warning
     close_sinks: warning
     empty_catches: warning
@@ -108,16 +118,11 @@ analyzer:
     empty_statements: warning
     file_names: warning
     hash_and_equals: warning
-    invalid_use_of_protected_member: warning
-    invalid_use_of_visible_for_testing_member: warning
     implementation_imports: warning
     iterable_contains_unrelated_type: warning
     library_names: warning
     library_prefixes: warning
     list_remove_unrelated_type: warning
-    missing_required_param: warning
-    missing_return: warning
-    must_call_super: warning
     no_adjacent_strings_in_list: warning
     no_duplicate_case_values: warning
     null_closures: warning
@@ -130,7 +135,6 @@ analyzer:
     prefer_is_not_empty: warning
     recursive_getters: warning
     slash_for_doc_comments: warning
-    subtype_of_sealed_class: warning
     type_init_formals: warning
     unnecessary_const: warning
     unnecessary_new: warning
@@ -160,7 +164,6 @@ linter:
     - await_only_futures
     - camel_case_extensions
     - camel_case_types
-    - can_be_null_after_null_aware
     - cancel_subscriptions
     - close_sinks
     - empty_catches
@@ -168,16 +171,11 @@ linter:
     - empty_statements
     - file_names
     - hash_and_equals
-    - invalid_use_of_protected_member
-    - invalid_use_of_visible_for_testing_member
     - implementation_imports
     - iterable_contains_unrelated_type
     - library_names
     - library_prefixes
     - list_remove_unrelated_type
-    - missing_required_param
-    - missing_return
-    - must_call_super
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - null_closures
@@ -190,7 +188,6 @@ linter:
     - prefer_is_not_empty
     - recursive_getters
     - slash_for_doc_comments
-    - subtype_of_sealed_class
     - type_init_formals
     - unnecessary_const
     - unnecessary_new

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -1,0 +1,192 @@
+# Copyright 2019 Workiva, Inc.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This software is derived from pedantic (https://github.com/dart-lang/pedantic)
+# with separate copyright notices and license terms:
+#
+# Copyright 2017, the Dart project authors. All rights reserved.
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following
+# disclaimer in the documentation and/or other materials provided
+# with the distribution.
+# Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived
+# from this software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Every lint in this file is categorized as "required".
+#
+# For context on that decision or to discuss a change for any individual lint,
+# visit this issue and search for the lint by its name:
+# https://github.com/Workiva/workiva_analysis_options/issues/2
+
+analyzer:
+  errors:
+    # Protect against using language features that are incompatible with the
+    # minimum SDK version for the current project:
+    sdk_version_async_exported_from_core: warning
+    sdk_version_as_expression_in_const_context: warning
+    sdk_version_bool_operator_in_const_context: warning
+    sdk_version_eq_eq_operator_in_const_context: warning
+    sdk_version_extension_methods: warning
+    sdk_version_is_expression_in_const_context: warning
+    sdk_version_set_literal: warning
+    sdk_version_ui_as_code: warning
+    sdk_version_ui_as_code_in_const_context: warning
+
+    # Promote some builtin hints/infos/warnings to errors:
+    dead_code: warning
+    duplicate_hidden_name: warning
+    duplicate_import: warning
+    duplicate_shown_name: warning
+    unused_catch_clause: warning
+    unused_catch_stack: warning
+    # Disabled during the Dart 2.13 transition
+    # unused_element: warning
+    # unused_field: warning
+    # unused_import: warning
+    unused_local_variable: warning
+    unused_shown_name: warning
+
+    # Promote enabled lints to errors:
+    annotate_overrides: warning
+    avoid_double_and_int_checks: warning
+    avoid_empty_else: warning
+    avoid_init_to_null: warning
+    avoid_private_typedef_functions: warning
+    avoid_return_types_on_setters: warning
+    avoid_shadowing_type_parameters: warning
+    avoid_single_cascade_in_expression_statements: warning
+    avoid_types_as_parameter_names: warning
+    await_only_futures: warning
+    camel_case_extensions: warning
+    camel_case_types: warning
+    cancel_subscriptions: warning
+    close_sinks: warning
+    empty_catches: warning
+    empty_constructor_bodies: warning
+    empty_statements: warning
+    file_names: warning
+    hash_and_equals: warning
+    implementation_imports: warning
+    iterable_contains_unrelated_type: warning
+    library_names: warning
+    library_prefixes: warning
+    list_remove_unrelated_type: warning
+    no_adjacent_strings_in_list: warning
+    no_duplicate_case_values: warning
+    null_closures: warning
+    only_throw_errors: warning
+    prefer_contains: warning
+    prefer_equal_for_default_values: warning
+    prefer_generic_function_type_aliases: warning
+    prefer_if_null_operators: warning
+    prefer_is_empty: warning
+    prefer_is_not_empty: warning
+    recursive_getters: warning
+    slash_for_doc_comments: warning
+    type_init_formals: warning
+    unnecessary_const: warning
+    unnecessary_new: warning
+    unnecessary_null_aware_assignments: warning
+    unnecessary_null_in_if_null_operators: warning
+    unnecessary_statements: warning
+    # Disabled during the Dart 2.13 transition
+    # unsafe_html: warning
+    unrelated_type_equality_checks: warning
+    valid_regexps: warning
+    void_checks: warning
+
+    # Ignore ungenerated uri error:
+    # See: <https://github.com/Workiva/over_react/blob/new_boilerplate_wip/doc/new_boilerplate_migration.md#ignore-ungenerated-warnings-project-wide>.
+    uri_has_not_been_generated: ignore
+
+linter:
+  rules:
+    - annotate_overrides
+    - avoid_double_and_int_checks
+    - avoid_empty_else
+    - avoid_init_to_null
+    - avoid_private_typedef_functions
+    - avoid_return_types_on_setters
+    - avoid_shadowing_type_parameters
+    - avoid_single_cascade_in_expression_statements
+    - avoid_types_as_parameter_names
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - cancel_subscriptions
+    - close_sinks
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - file_names
+    - hash_and_equals
+    - implementation_imports
+    - iterable_contains_unrelated_type
+    - library_names
+    - library_prefixes
+    - list_remove_unrelated_type
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - null_closures
+    - only_throw_errors
+    - prefer_contains
+    - prefer_equal_for_default_values
+    - prefer_generic_function_type_aliases
+    - prefer_if_null_operators
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - recursive_getters
+    - slash_for_doc_comments
+    - type_init_formals
+    - unnecessary_const
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_statements
+    # Disabled during the Dart 2.13 transition
+    # - unsafe_html
+    - unrelated_type_equality_checks
+    - valid_regexps
+    - void_checks


### PR DESCRIPTION
View second commit to see additions

To see examples: `https://dart-lang.github.io/linter/lints/$insert_lint_here$.html`

RP has customized analysis options that we believe could be beneficial to make standard across the org, and beneficial to us as we try to break apart `doc_plat_client`. This PR introduces a v2 with some additions that we have found helpful. 