### PR TITLE
Fix v2.recommended importing v1 instead of v2

### DIFF
--- a/lib/v2.recommended.yaml
+++ b/lib/v2.recommended.yaml
@@ -61,7 +61,7 @@
 # https://github.com/Workiva/workiva_analysis_options/issues/2
 
 # This file also includes all of the required rules.
-include: package:workiva_analysis_options/v1.yaml
+include: package:workiva_analysis_options/v2.yaml
 
 analyzer:
   errors:


### PR DESCRIPTION
I noticed that v2.recommended.yaml imports v1.yaml instead of v2.yaml. This seemed like a copy-paste error.