### PR TITLE
Promote invalid_export_of_internal_element to warning

### DIFF
--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -81,6 +81,7 @@ analyzer:
     duplicate_ignore: warning
     duplicate_import: warning
     duplicate_shown_name: warning
+    invalid_export_of_internal_element: warning
     invalid_required_named_param: warning
     invalid_required_positional_param: warning
     invalid_use_of_protected_member: warning


### PR DESCRIPTION
From #179

> This is the hint associated with [the @internal annotation from the meta package](https://pub.dev/documentation/meta/latest/meta/internal-constant.html).

> I think we should upgrade this to a warning in the v2 base set of lints, to help prevent accidentally exporting APIs that shouldn't be exported.