### PR TITLE
Add NNBD-related lints

### DIFF
--- a/lib/v1.yaml
+++ b/lib/v1.yaml
@@ -102,6 +102,7 @@ analyzer:
     camel_case_extensions: warning
     camel_case_types: warning
     cancel_subscriptions: warning
+    cast_nullable_to_non_nullable: warning
     close_sinks: warning
     empty_catches: warning
     empty_constructor_bodies: warning
@@ -115,6 +116,7 @@ analyzer:
     list_remove_unrelated_type: warning
     no_adjacent_strings_in_list: warning
     no_duplicate_case_values: warning
+    null_check_on_nullable_type_parameter: warning
     null_closures: warning
     only_throw_errors: warning
     prefer_contains: warning
@@ -125,6 +127,7 @@ analyzer:
     prefer_is_not_empty: warning
     recursive_getters: warning
     slash_for_doc_comments: warning
+    tighten_type_of_initializing_formals: warning
     type_init_formals: warning
     unnecessary_const: warning
     unnecessary_new: warning
@@ -156,6 +159,7 @@ linter:
     - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
+    - cast_nullable_to_non_nullable
     - close_sinks
     - empty_catches
     - empty_constructor_bodies
@@ -169,6 +173,7 @@ linter:
     - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
+    - null_check_on_nullable_type_parameter
     - null_closures
     - only_throw_errors
     - prefer_contains
@@ -179,6 +184,7 @@ linter:
     - prefer_is_not_empty
     - recursive_getters
     - slash_for_doc_comments
+    - tighten_type_of_initializing_formals
     - type_init_formals
     - unnecessary_const
     - unnecessary_new

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -113,6 +113,7 @@ analyzer:
     camel_case_extensions: warning
     camel_case_types: warning
     cancel_subscriptions: warning
+    cast_nullable_to_non_nullable: warning
     close_sinks: warning
     empty_catches: warning
     empty_constructor_bodies: warning
@@ -126,6 +127,7 @@ analyzer:
     list_remove_unrelated_type: warning
     no_adjacent_strings_in_list: warning
     no_duplicate_case_values: warning
+    null_check_on_nullable_type_parameter: warning
     null_closures: warning
     only_throw_errors: warning
     prefer_contains: warning
@@ -136,6 +138,7 @@ analyzer:
     prefer_is_not_empty: warning
     recursive_getters: warning
     slash_for_doc_comments: warning
+    tighten_type_of_initializing_formals: warning
     type_init_formals: warning
     unnecessary_const: warning
     unnecessary_new: warning
@@ -171,6 +174,7 @@ linter:
     - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
+    - cast_nullable_to_non_nullable
     - close_sinks
     - empty_catches
     - empty_constructor_bodies
@@ -184,6 +188,7 @@ linter:
     - list_remove_unrelated_type
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
+    - null_check_on_nullable_type_parameter
     - null_closures
     - only_throw_errors
     - prefer_contains
@@ -194,6 +199,7 @@ linter:
     - prefer_is_not_empty
     - recursive_getters
     - slash_for_doc_comments
+    - tighten_type_of_initializing_formals
     - type_init_formals
     - unnecessary_const
     - unnecessary_new


### PR DESCRIPTION
There are a few lints related to null-safe code that would be helpful to have in place as we start our NNBD migrations. These should be safe to add to existing rulesets because they only apply to null-safe code, and as such should have no impact on existing non-migrated code.