### PR TITLE
FEDX-530: Remove `sdk_version_<language_feature>` rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.4.1
+
+- [#200](https://github.com/Workiva/workiva_analysis_options/pull/200) Remove
+`sdk_version_<language_feature>` rules. These were diagnostics produced by the
+analyzer when a language feature was used without specifying the proper minimum
+SDK version and this package was promoting them to errors since earlier versions
+of Dart did not do that by default. They are no longer necessary.
+
+## 1.4.0
+
+- [#198](https://github.com/Workiva/workiva_analysis_options/pull/198) Add NNBD-related lints
+
 ## 1.3.0
 
 - Add `v2` rulesets:

--- a/lib/v1.yaml
+++ b/lib/v1.yaml
@@ -62,18 +62,6 @@
 
 analyzer:
   errors:
-    # Protect against using language features that are incompatible with the
-    # minimum SDK version for the current project:
-    sdk_version_async_exported_from_core: warning
-    sdk_version_as_expression_in_const_context: warning
-    sdk_version_bool_operator_in_const_context: warning
-    sdk_version_eq_eq_operator_in_const_context: warning
-    sdk_version_extension_methods: warning
-    sdk_version_is_expression_in_const_context: warning
-    sdk_version_set_literal: warning
-    sdk_version_ui_as_code: warning
-    sdk_version_ui_as_code_in_const_context: warning
-
     # Promote some builtin hints to warnings:
     dead_code: warning
     duplicate_hidden_name: warning

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -62,18 +62,6 @@
 
 analyzer:
   errors:
-    # Protect against using language features that are incompatible with the
-    # minimum SDK version for the current project:
-    sdk_version_as_expression_in_const_context: warning
-    sdk_version_async_exported_from_core: warning
-    sdk_version_bool_operator_in_const_context: warning
-    sdk_version_eq_eq_operator_in_const_context: warning
-    sdk_version_extension_methods: warning
-    sdk_version_is_expression_in_const_context: warning
-    sdk_version_set_literal: warning
-    sdk_version_ui_as_code_in_const_context: warning
-    sdk_version_ui_as_code: warning
-
     # Promote some builtin hints to warnings:
     can_be_null_after_null_aware: warning
     dead_code: warning


### PR DESCRIPTION
On older versions of Dart (early days of 2.x), the process around introducing new language features wasn't as mature as it is today. If you used a language feature without raising the SDK minimum for your package to the appropriate version, you'd get a diagnostic from the analyzer but it wasn't an error. So, this package promoted those diagnostics to errors to ensure that you wouldn't miss them.

Here are the rules that we configured:

| Rule | Docs | Supported since Dart |
| ---- | --------- | --------------- |
| `sdk_version_async_exported_from_core` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_async_exported_from_core) | 2.1.0 |
| `sdk_version_as_expression_in_const_context` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_as_expression_in_const_context) | 2.3.2 |
| `sdk_version_bool_operator_in_const_context` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_bool_operator_in_const_context) | 2.3.2 |
| `sdk_version_eq_eq_operator_in_const_context` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_eq_eq_operator_in_const_context) | 2.3.2 |
| `sdk_version_extension_methods` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_extension_methods) | 2.6.0 |
| `sdk_version_is_expression_in_const_context` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_is_expression_in_const_context) | 2.3.2 |
| `sdk_version_set_literal` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_set_literal) | 2.2.0 |
| `sdk_version_ui_as_code` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_ui_as_code) | 2.3.0 |
| `sdk_version_ui_as_code_in_const_context` | [link](https://dart.dev/tools/diagnostic-messages#sdk_version_ui_as_code_in_const_context) | 2.5.0 |


Dart 3.2.0 was just released and dropped support for those diagnostics, meaning that any package with an `analysis_options.yaml` that includes those rules would receive a warning from the analyzer like this:

```
warning • analysis_options.yaml:1:10 • Warning in the included options file workiva_analysis_options/lib/v2.yaml(3923..3944): 'sdk_version_ui_as_code' isn't a recognized error code. • included_file_warning
```

For the diagnostics listed above, the corresponding language features have been supported since Dart 2.6 or earlier. This package already specifies a minimum SDK version of 2.12.0, so there's no need to include these rules any longer.