### PR TITLE
remove reference to a hint that was removed in Dart 3 `can_be_null_after_null_aware`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.2
+
+- remove reference to a hint that was removed in Dart 3 `can_be_null_after_null_aware`
+
 ## 1.4.1
 
 - [#200](https://github.com/Workiva/workiva_analysis_options/pull/200) Remove

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -63,7 +63,6 @@
 analyzer:
   errors:
     # Promote some builtin hints to warnings:
-    can_be_null_after_null_aware: warning
     dead_code: warning
     duplicate_hidden_name: warning
     duplicate_ignore: warning


### PR DESCRIPTION
# Summary

workiva_analysis_options breaks under Dart 3 because a hint was removed that we were promoting to a warning. Let's just remove that hint reference

# Changes

- remove reference to a hint that was removed in Dart 3 `can_be_null_after_null_aware`