### PR TITLE
Warn on legacy imports

### DIFF
--- a/lib/v1.recommended.yaml
+++ b/lib/v1.recommended.yaml
@@ -84,6 +84,7 @@ analyzer:
     cascade_invocations: warning
     comment_references: warning
     curly_braces_in_flow_control_structures: warning
+    import_of_legacy_library_into_null_safe: warning
     join_return_with_assignment: warning
     omit_local_variable_types: warning
     overridden_fields: warning

--- a/lib/v1.yaml
+++ b/lib/v1.yaml
@@ -98,6 +98,7 @@ analyzer:
     file_names: warning
     hash_and_equals: warning
     implementation_imports: warning
+    import_of_legacy_library_into_null_safe: warning
     iterable_contains_unrelated_type: warning
     library_names: warning
     library_prefixes: warning
@@ -184,3 +185,4 @@ linter:
     - unrelated_type_equality_checks
     - valid_regexps
     - void_checks
+    

--- a/lib/v2.recommended.yaml
+++ b/lib/v2.recommended.yaml
@@ -90,6 +90,7 @@ analyzer:
     control_flow_in_finally: warning
     curly_braces_in_flow_control_structures: warning
     directives_ordering: warning
+    import_of_legacy_library_into_null_safe: warning
     join_return_with_assignment: warning
     literal_only_boolean_expressions: warning
     omit_local_variable_types: warning

--- a/lib/v2.yaml
+++ b/lib/v2.yaml
@@ -108,6 +108,7 @@ analyzer:
     file_names: warning
     hash_and_equals: warning
     implementation_imports: warning
+    import_of_legacy_library_into_null_safe: warning
     iterable_contains_unrelated_type: warning
     library_names: warning
     library_prefixes: warning


### PR DESCRIPTION
Upgrade `import_of_legacy_library_into_null_safe` to a warning